### PR TITLE
Change to Graphite detection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Pankosmia Editor" />

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/components/GraphiteTest.jsx
+++ b/src/components/GraphiteTest.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import {useDetectRender} from 'font-detect-rhl';
+
+export default function GraphiteTest() {
+
+  const [testFont, setTestFont] = useState('');
+  const [hasRunOnce, setHasRunOnce] = useState(false);
+
+  const font = new FontFace("Pankosmia-GraphiteTest", "url(/webfonts/awami/AwamiNastaliq-Regular.woff2)", {
+    style: "normal",
+    weight: "normal",
+  });
+
+  document.fonts.add(font);
+  
+  async function check() {
+    await font.load();
+    setTestFont('Pankosmia-GraphiteTest');
+  }
+
+  useEffect ( () => {
+    if (!hasRunOnce) {
+      check();
+      setHasRunOnce(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[hasRunOnce])
+
+  const testFontArray = [{ name: testFont }];
+  const renderType = useDetectRender({fonts:testFontArray});
+  const isGraphite = renderType[0].detectedRender === 'RenderingGraphite';
+
+  return isGraphite;
+}

--- a/src/components/PdfGenerate.jsx
+++ b/src/components/PdfGenerate.jsx
@@ -27,7 +27,7 @@ import {Proskomma} from 'proskomma-core';
 import {SofriaRenderFromProskomma, render} from "proskomma-json-tools";
 import {getText, debugContext, i18nContext, doI18n, typographyContext} from "pithekos-lib";
 import {enqueueSnackbar} from "notistack";
-import { useAssumeGraphite } from "font-detect-rhl";
+import { useDetectRender, useAssumeGraphite } from "font-detect-rhl";
 import {getCVTexts, getBookName} from "../helpers/cv";
 
 function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
@@ -53,6 +53,11 @@ function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
 
 
     const isFirefox = useAssumeGraphite({});
+
+    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
+    const renderType = useDetectRender({fonts:testFont});
+    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
+    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     const generatePdf = async (bookCode, pdfType="para") => {
         let pdfHtml;
@@ -176,8 +181,8 @@ function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
         }
         const newPage = isFirefox ? window.open("", "_self") : window.open('about:blank', '_blank');
         const server = window.location.origin;
-        if (!isFirefox) newPage.document.body.innerHTML = `<div class="${typographyRef.current.font_set}">${pdfHtml}</div>`
-        isFirefox && newPage.document.write(`<div class="${typographyRef.current.font_set}">${pdfHtml}</div>`);  
+        if (!isFirefox) newPage.document.body.innerHTML = `<div class="${selectedFontClass}">${pdfHtml}</div>`
+        isFirefox && newPage.document.write(`<div class="${selectedFontClass}">${pdfHtml}</div>`);  
         newPage.document.head.innerHTML = '<title>PDF Preview</title>'
         const script = document.createElement('script')
         script.src = `${server}/app-resources/pdf/paged.polyfill.js`;

--- a/src/components/PdfGenerate.jsx
+++ b/src/components/PdfGenerate.jsx
@@ -56,7 +56,7 @@ function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
     const isFirefox = useAssumeGraphite({});
 
     const isGraphite = GraphiteTest()
-    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    /** adjSelectedFontClass reshapes selectedFontClass if Graphite is absent. */
     const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     const generatePdf = async (bookCode, pdfType="para") => {

--- a/src/components/PdfGenerate.jsx
+++ b/src/components/PdfGenerate.jsx
@@ -27,8 +27,9 @@ import {Proskomma} from 'proskomma-core';
 import {SofriaRenderFromProskomma, render} from "proskomma-json-tools";
 import {getText, debugContext, i18nContext, doI18n, typographyContext} from "pithekos-lib";
 import {enqueueSnackbar} from "notistack";
-import { useDetectRender, useAssumeGraphite } from "font-detect-rhl";
+import { useAssumeGraphite } from "font-detect-rhl";
 import {getCVTexts, getBookName} from "../helpers/cv";
+import GraphiteTest from './GraphiteTest';
 
 function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
 
@@ -54,10 +55,9 @@ function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
 
     const isFirefox = useAssumeGraphite({});
 
-    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
-    const renderType = useDetectRender({fonts:testFont});
-    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
-    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
+    const isGraphite = GraphiteTest()
+    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     const generatePdf = async (bookCode, pdfType="para") => {
         let pdfHtml;
@@ -181,8 +181,8 @@ function PdfGenerate({bookNames, repoSourcePath, open, closeFn}) {
         }
         const newPage = isFirefox ? window.open("", "_self") : window.open('about:blank', '_blank');
         const server = window.location.origin;
-        if (!isFirefox) newPage.document.body.innerHTML = `<div class="${selectedFontClass}">${pdfHtml}</div>`
-        isFirefox && newPage.document.write(`<div class="${selectedFontClass}">${pdfHtml}</div>`);  
+        if (!isFirefox) newPage.document.body.innerHTML = `<div class="${adjSelectedFontClass}">${pdfHtml}</div>`
+        isFirefox && newPage.document.write(`<div class="${adjSelectedFontClass}">${pdfHtml}</div>`);  
         newPage.document.head.innerHTML = '<title>PDF Preview</title>'
         const script = document.createElement('script')
         script.src = `${server}/app-resources/pdf/paged.polyfill.js`;


### PR DESCRIPTION
### This PR is for use in conjunction with or before the planned Electronite version of Liminal.
- Instead detecting the presence of Firefox, this upgrade detects when Graphite rendering exists, whatever the client.

### Important: Please accept "Change to Graphite detection." PRs on the following repos at the same time:
- core-client-settings
- core-client-workspace 
- core-client-content
- core-client-i18n-editor 
- webfonts-core: _Contains new font classes in support of the changes above._
- pankosmia-web: _keeping 1 version of font "truth" until such time as they are no longer included here_
- pithekos: _keeping: 1 version of font "truth" until such time as they are no longer included here_

### Changes to process flow in this repo:
- GraphiteTest(): Confirm the testFont has loaded, then useDetectRender
- If there is no Graphite then font_set is re-shaped to avoid bonked Awami.
- If Graphite is running then font_set is applied directly.
