### PR TITLE
Now the source column is displaying in the normal view.

### DIFF
--- a/src/components/DataGridComponent.jsx
+++ b/src/components/DataGridComponent.jsx
@@ -143,7 +143,7 @@ function DataGridComponent({isContentExperiment, contentUrl, experimentDialogOpe
                     columns: {
                         columnVisibilityModel: {
                             nBooks: false,
-                            source: false,
+                            source: isContentExperiment ? false : true,
                             dateUpdated: false
                         },
                     },


### PR DESCRIPTION
This PR addresses issue #57 

Now the source column is displaying in the normal view and not in the other views.