### PR TITLE
English Human Redable ISO 639-1 Codes

### DIFF
--- a/src/components/DataGridComponent.jsx
+++ b/src/components/DataGridComponent.jsx
@@ -13,6 +13,7 @@ function DataGridComponent({reposModCount, setReposModCount, isNormal, contentFi
     const {i18nRef} = useContext(i18nContext);
     const {enabledRef} = useContext(netContext);
     const [projectSummaries, setProjectSummaries] = useState({});
+    const [languageLookup, setLanguageLookup] = useState([]);
 
     const sourceWhitelist = [
         ["git.door43.org/BurritoTruck", "Xenizo curated content (Door43)"],
@@ -37,6 +38,12 @@ function DataGridComponent({reposModCount, setReposModCount, isNormal, contentFi
         },
         [reposModCount, experimentDialogOpen]
     );
+
+    useEffect(() => {
+      fetch('/app-resources/lookups/languages.json') // ISO_639-1 plus grc
+        .then(r => r.json())
+        .then(data => setLanguageLookup(data));
+    }, []);
 
     useEffect(
         () => {
@@ -214,7 +221,8 @@ function DataGridComponent({reposModCount, setReposModCount, isNormal, contentFi
             ...rep,
             id: n,
             name: `${rep.name.trim()}${rep.description.trim() !== rep.name.trim() ? ": " + rep.description.trim() : ""}`,
-            language: rep.language_code,
+            language: languageLookup.find(x => x?.id === rep.language_code)?.en ??
+                      rep.language_code,
             nBooks: rep.book_codes.length,
             type: rep.flavor,
             source: rep.path.startsWith("_local_") ?


### PR DESCRIPTION
This applies the english language name for two-letter ISO 639-1 from the lookup json that we added fairly recently to resource-core.  It leave 3-digit codes displayed as 3-digit codes (see arb in the screenshot) and only applies the name to the 2-digit codes (see the other highlighted items in the screenshot.

<img width="1282" height="530" alt="image" src="https://github.com/user-attachments/assets/1a6d736a-1e45-4894-9138-2e854a291dfe" />
