### PR TITLE
add version manager routing

### DIFF
--- a/src/components/ContentRowButtonPlusMenu.jsx
+++ b/src/components/ContentRowButtonPlusMenu.jsx
@@ -104,6 +104,22 @@ function ContentRowButtonPlusMenu({
       return [];
     })
     .flat();
+
+  const createVersionManager = Object.entries(menu)
+    .filter(([, value]) => value.manager)
+    .flatMap(([category, value]) => {
+      const managerArray = value.manager;
+      if (Array.isArray(managerArray)) {
+        return managerArray.map((item) => ({
+          category,
+          label: doI18n(`${item.label}`, i18nRef.current),
+          url: item.url,
+        }));
+      }
+      return [];
+    })
+    .flat();
+  console.log(createVersionManager);
   const hasExport = createItemExport.some(
     (item) => item.category === repoInfo.flavor
   );
@@ -226,22 +242,27 @@ function ContentRowButtonPlusMenu({
               </Typography>
             </MenuItem>
             <Divider />
-            {repoInfo.path.includes("_local_/_local_") && (
-              <>
-                <MenuItem
-                  onClick={() => {
-                    window.location.href = `/clients/core-contenthandler_version_manager#/version_manager?repoPath=${repoInfo.path}`;
-                  }}
-                  disabled={
-                    !repoInfo.path.split("/")[0] === "_local_" ||
-                    repoInfo.path.split("/")[1] === "_updates_"
-                  }
-                >
-                  {doI18n("pages:content:version_manager", i18nRef.current)}
-                </MenuItem>
-                <Divider />
-              </>
-            )}
+            {repoInfo.path.includes("_local_/_local_") &&
+              createVersionManager.length > 0 && (
+                <>
+                  {createVersionManager.map((vm) => (
+                    <MenuItem
+                      onClick={() => {
+                        window.location.href =
+                          vm.url + `?repoPath=${repoInfo.path}`;
+                      }}
+                      disabled={
+                        !repoInfo.path.split("/")[0] === "_local_" ||
+                        repoInfo.path.split("/")[1] === "_updates_"
+                      }
+                    >
+                      {doI18n("pages:content:version_manager", i18nRef.current)}
+                    </MenuItem>
+                  ))}
+
+                  <Divider />
+                </>
+              )}
             <MenuItem
               onClick={(event) => {
                 setDeleteContentAnchorEl(event.currentTarget);


### PR DESCRIPTION
## Add automatic routing for Version Manager in `core-client-content`

### Summary
This PR introduces **automatic routing for the Version Manager** inside `core-client-content`.

The goal is to ensure that the Version Manager UI is **only exposed when the `core-contentHandler_version_manager` is available**, and remains hidden otherwise.

---

### Behavior

- **Without** `core-contentHandler_version_manager`
  - ❌ No Version Manager button is displayed

- **With** `core-contentHandler_version_manager`
  - Version Manager button is displayed
  - Available for **local resources**

This makes the UI behavior consistent with the underlying capabilities and avoids exposing unavailable features.

---

###  How to Test
Main branch of `core-contenthandler_version_manager`

1. **Disable** `core-contenthandler_version_manager`
   - Verify that the Version Manager button is **not present**

2. **Enable** `core-contentHandler_version_manager`
   - Verify that the Version Manager button **appears**
   - Confirm it works correctly with **local resources**

---

### Demo


![Version Manager automatic routing demo](https://github.com/user-attachments/assets/460e734c-c074-4155-9cb1-74c0194fe939)


