### PR TITLE
Change Share > Share as to Export > Save as

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -140,7 +140,7 @@
     "export": {
       "en": "Export",
       "es": "Exportar",
-      "fr": "@Partager",
+      "fr": "Exporter",
       "id": "Ekspor"
     },
 
@@ -191,7 +191,7 @@
     },
     "export_docx": {
       "en": "Save as DOCX (Word document)",
-      "fr": "@Partager au format DOCX (document Word)",
+      "fr": "Sauvegarder au format DOCX (document Word)",
       "id": "Simpan konten sebagai dokumen Word"
     },
 
@@ -792,7 +792,7 @@
     },
     "generate_pdf": {
       "en": "Save as PDF",
-      "fr": "@Partager au format PDF",
+      "fr": "Sauvegarder au format PDF",
       "id": "Simpan sebagai PDF"
     },
 
@@ -825,28 +825,29 @@
     },
     "export_pdf": {
       "en": "Save as PDF",
-      "fr": "@Partager au format PDF",
+      "fr": "Sauvegarder au format PDF",
       "id": "Simpan sebagai PDF"
     },
     "export_usfm": {
       "en": "Save as USFM",
-      "fr": "@Partager au format USFM",
+      "fr": "Sauvegarder au format USFM",
       "id": "Simpan sebagai USFM"
     },
     "export_zip": {
       "en": "Save as ZIP",
-      "fr": "@Partager au format ZIP",
+      "fr": "Sauvegarder au format ZIP",
       "id": "Simpan sebagai ZIP"
     },
     "export_burrito": {
       "en": "Save as Burrito",
       "es": "@Compartir como Burrito",
-      "fr": "@Partager au format Burrito",
+      "fr": "Sauvegarder au format Burrito",
       "id": "Simpan sebagai Burrito"
     },
     "burrito_exported": {
-      "en": "Burrito was succesfuly saved",
+      "en": "Burrito was successfuly saved",
       "es": "@El burrito fue exportado correctamente",
+      "fr": "Burrito sauvegardé avec succès",
       "id": "Burrito telah disimpan"
     },
     "could_not_export_burrito": {
@@ -855,7 +856,7 @@
     },
     "do_export": {
       "en": "Save",
-      "es": "@Exportar",
+      "es": "Sauvegarder",
       "id": "Simpan"
     },
     "about_to_export_burrito": {
@@ -864,7 +865,7 @@
     },
     "about_document": {
       "en": "About",
-      "fr": "A propos"
+      "fr": "À propos"
     },
     "about_repo_flavor": {
       "en": "Type",


### PR DESCRIPTION
This changes "Share > Share" as to "Export > Save as" from the Documents ellipsis` on applicable rows.

| | | |
|---|---|---|
| <img width="308" height="290" alt="image" src="https://github.com/user-attachments/assets/38aa46e4-b302-46f5-a75d-df5a5d3811b5" /> |  <img width="901" height="214" alt="image" src="https://github.com/user-attachments/assets/5e55cc8f-028c-4837-b9ec-daa7d2e2ff12" /> | <img width="364" height="65" alt="image" src="https://github.com/user-attachments/assets/fe2ed2ab-5e7f-475d-8eb1-021abdc5c644" /> |
